### PR TITLE
Fix rglfw path typo

### DIFF
--- a/raylib.build.zig
+++ b/raylib.build.zig
@@ -177,7 +177,7 @@ pub const RaylibSetup = struct {
     ) !void {
         // On macos rglfw.c include Objective-C files.
         try self.flags.append("-ObjC");
-        const cRglfw = b.pathJoin(&[_][]const u8{ self.raylibSrcPath.getPath(b), "rlgfw.c" });
+        const cRglfw = b.pathJoin(&[_][]const u8{ self.raylibSrcPath.getPath(b), "rglfw.c" });
         step.root_module.addCSourceFile(.{
             .file = .{ .path = cRglfw },
             .flags = self.flags.items,


### PR DESCRIPTION
Had build issue when following the readme due to a typo. Tested and worked with this minor change. Nice work so far!